### PR TITLE
Changed JSONReader to read in docID as a string

### DIFF
--- a/parser/src/main/scala/com/clearcut/nlp/JSONReader.scala
+++ b/parser/src/main/scala/com/clearcut/nlp/JSONReader.scala
@@ -27,7 +27,7 @@ class JSONReader(input:Source,
 
       val jsObj = Json.parse(line).asInstanceOf[JsObject]
 
-      val maybeDocumentId = jsObj.value.get(idKey).map(_.asInstanceOf[JsValue].toString)
+      val maybeDocumentId = jsObj.value.get(idKey).map(_.asInstanceOf[JsString].value)
       val maybeDocumentStr = jsObj.value.get(documentKey).map(_.asInstanceOf[JsString].value)
 
       (maybeDocumentId, maybeDocumentStr) match {


### PR DESCRIPTION
All of the doc_id values were being put into the db with quotes wrapping them.  Is there ever a case where our docid can't be treated as a string?
