### PR TITLE
Temporary fix for weird bug where brackets cause problems

### DIFF
--- a/parser/src/main/scala/com/clearcut/nlp/DocumentParser.scala
+++ b/parser/src/main/scala/com/clearcut/nlp/DocumentParser.scala
@@ -16,7 +16,11 @@ class DocumentParser(props: Properties) {
 
   def parseDocumentString(doc: String) = {
 
-    val document = new Annotation(doc)
+    // Temporary fix for bug where brackets are being incorrectly treated as punct
+    // and somehow this messes up the whole dep parse -> change them to round braces
+    val doc2 = doc.replaceAll("""\[""", "(").replaceAll("""\]""", ")")
+
+    val document = new Annotation(doc2)
     pipeline.annotate(document)
     // val dcoref = document.get(classOf[CorefChainAnnotation])
     val sentences = document.get(classOf[SentencesAnnotation])


### PR DESCRIPTION
Brackets are parsed as punctuation somehow in the dep parse, and somehow this messes up the whole parse in larger ways.  Simple fix is to change e.g. [ -> (, which shouldn't bother anyone... this error doesn't show up in the coreNLP demo, however it does in both the shift-reduce and NN parsers.  Perhaps some minor bug in general transition-based parser framework in coreNLP?