### PR TITLE
Adds support for config.properties file to adjust settings for CoreNLP

### DIFF
--- a/pipe/build.sbt
+++ b/pipe/build.sbt
@@ -16,12 +16,13 @@ libraryDependencies ++= List(
   "ch.qos.logback" % "logback-classic" % "1.0.7",
   "com.typesafe.play" %% "play-json" % "2.3.4",
   "com.github.scopt" %% "scopt" % "3.2.0",
-  "edu.stanford.nlp" % "stanford-corenlp" % "3.5.2",
-  "edu.stanford.nlp" % "stanford-corenlp" % "3.5.2" classifier "models",
+  "edu.stanford.nlp" % "stanford-corenlp" % "3.6.0",
+  "edu.stanford.nlp" % "stanford-corenlp" % "3.6.0" classifier "models",
   "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test",
   "org.http4s" %% "http4s-dsl" % "0.7.0",
   "org.http4s" %% "http4s-jetty" % "0.7.0",
-  "org.json4s" %% "json4s-jackson" % "3.2.11"
+  "org.json4s" %% "json4s-jackson" % "3.2.11",
+  "org.jsoup" % "jsoup" % "1.8.3"
 )
 
 unmanagedJars in Compile += file("lib/stanford-srparser-2014-10-23-models.jar")

--- a/pipe/config.properties.template
+++ b/pipe/config.properties.template
@@ -1,0 +1,2 @@
+tokenize.whitespace = true
+ssplit.eolonly = true

--- a/pipe/example/input.json
+++ b/pipe/example/input.json
@@ -1,0 +1,1 @@
+{ "doc_id":"1", "content":"I was robbed by this girl.&nbsp;<div>:(" }

--- a/pipe/example/parse.sh
+++ b/pipe/example/parse.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+../run.sh --formatIn json --formatOut json -v content -k doc_id -a ExtendedCleanHtmlStanfordPipeline -i input.json -o output.json

--- a/pipe/run_parallel.sh
+++ b/pipe/run_parallel.sh
@@ -1,24 +1,35 @@
-#!/bin/sh
-# Parse sentences in parallel
+#!/usr/bin/env bash
 
+# Parses documents in parallel.
+#
+# Input is a single file that contains one JSON record per line.
+# Output is a single file that contains one JSON record per line.
+# 
+# The number of records and their order is the same in input and output.
+#
 # Example:
-# ./run_parallel.sh --input=YOUR_INPUT.json --parallelism=1 '--formatIn json --formatOut column -v content -k doc_id -a ExtendedStanfordPipeline'
-
+# ./run_parallel.sh --input=INPUT.json --output=OUTPUT.json \
+#                   --params='-v content -k doc_id -a ExtendedCleanHtmlStanfordPipeline'
+#
+# The following environment variables are used when available.
+#   PARALLELISM (default 2)
+#   BATCH_SIZE  (default 1000)
 
 set -eu
-
-# Usage: this_script input_file parallelism input_batch_size
-
-if [ "$#" -le 1 ]; then
-  echo "Usage: $0 -i=input_file [--parallelism=PARALLELISM] [--batch-size=BATCH_SIZE ] <args for run.sh>"
-  exit
-fi
 
 for i in "$@"
 do
 case $i in
   -in=*|--input=*)
     INPUT_FILE="${i#*=}"
+    shift
+    ;;
+  -out=*|--output=*)
+    OUTPUT_FILE="${i#*=}"
+    shift
+    ;;
+  -pa=*|--params=*)
+    PARAMS="${i#*=}"
     shift
     ;;
   -p=*|--parallelism=*)
@@ -29,79 +40,98 @@ case $i in
     BATCH_SIZE="${i#*=}"
     shift
     ;;
+  --keepsplit)
+    KEEP_SPLIT=true
+    shift
+    ;;
     *)
-    echo "NO MATCH"
+    echo "Ignoring parameter: $i"
     break
     ;;
 esac
 done
 
 if [ -z "$INPUT_FILE" ]; then
-  echo "Usage: $0 -i=input_file [--parallelism=PARALLELISM] [--batch-size=BATCH_SIZE ] <args for run.sh>"
+  echo "Usage: $0 -in=INPUT.json [-out=OUTPUT.json] [--parallelism=PARALLELISM] \\"
+  echo "                    [--batch-size=BATCH_SIZE ] --params='<args for run.sh>'"
   exit
 fi
 
+# Setting defaults
 PARALLELISM=${PARALLELISM:-2}
 BATCH_SIZE=${BATCH_SIZE:-1000}
+OUTPUT_FILE=${OUTPUT_FILE:-$INPUT_FILE.out}
+PARAMS=${PARAMS:-}
 
 echo "parallelism = $PARALLELISM"
 echo "batch-size  = $BATCH_SIZE"
 
-RUN_SCRIPT=`cd $(dirname $0)/; pwd`"/run.sh $@"
+RUN_SCRIPT=`cd $(dirname $0)/; pwd`"/run.sh --formatIn json --formatOut json $PARAMS"
 echo $RUN_SCRIPT
-mkdir -p $INPUT_FILE.split
-rm -f $INPUT_FILE.split/*
+
+SPLIT_DIR=$INPUT_FILE.split
+mkdir -p $SPLIT_DIR
+rm -rf $SPLIT_DIR/*
 
 # Split the input file into subfiles
-split -a 10 -l $BATCH_SIZE $INPUT_FILE $INPUT_FILE.split/input-
+split -a 10 -l $BATCH_SIZE $INPUT_FILE $SPLIT_DIR/input-
 
 # Match all files in the split directory
 find $INPUT_FILE.split -name "input-*" 2>/dev/null -print0 | xargs -0 -P $PARALLELISM -L 1 bash -c "${RUN_SCRIPT}"' -i "$0" -o "$0.out"'
 
-#echo "The output is is $INPUT_FILE.split"
-
-#echo "If you generated TSV output, you can load it into your database using"
-#echo "cat $INPUT_FILE.split/*.parsed | psql YOUR_DB_NAME -c "'"COPY sentences FROM STDIN"'
-
-#echo "If you generated column output, you can merge the split columns using"
-#echo ""
-
-# merging column format segments
-
-SPLITDIR=$INPUT_FILE.split
-OUTDIR=$INPUT_FILE.out
-if [ -d "$OUTDIR" ]; then
-    echo "$OUTDIR already exists. Aborting."
-    exit 1
-fi
-mkdir $OUTDIR
+function merge_json_format {
+    SPLIT_DIR=$1
+    OUTPUT_FILE=$2
+    # merging json files
+    for file in $SPLIT_DIR/*.out
+    do
+        cat $file >> $OUTPUT_FILE
+    done
+}
 
 
-# first we determine the different annotators by looking at only one segment
-annotations=()
-for file in $SPLITDIR/*
-do
-    if [[ -d $file ]]; then
-        for ann in $file/*
-        do
-            annotations+=("${ann##*.}")
-        done
-        break
+function merge_column_format {
+    SPLIT_DIR=$1
+    OUTPUT_FILE=$2
+    # merging column format segments
+    
+    OUTDIR=$INPUT_FILE.out
+    if [ -d "$OUTDIR" ]; then
+        echo "$OUTDIR already exists. Aborting."
+        exit 1
     fi
-done
+    mkdir $OUTDIR
+    
+    # first we determine the different annotators by looking at only one segment
+    annotations=()
+    for file in $SPLIT_DIR/*
+    do
+        if [[ -d $file ]]; then
+            for ann in $file/*
+            do
+                annotations+=("${ann##*.}")
+            done
+            break
+        fi
+    done
+    
+    # now cat them all together
+    for file in $SPLIT_DIR/*
+    do
+        if [[ -d $file ]]; then
+            for ann in "${annotations[@]}"
+            do
+                cat $file/ann.$ann >> $OUTDIR/ann.$ann
+            done
+        fi
+    done
+}
 
-# now cat them all together
-for file in $SPLITDIR/*
-do
-    if [[ -d $file ]]; then
-        for ann in "${annotations[@]}"
-        do
-            cat $file/ann.$ann >> $OUTDIR/ann.$ann
-        done
-    fi
-done
+merge_json_format $SPLIT_DIR $OUTPUT_FILE
 
 # remove split dir
-rm -rf $SPLITDIR
+if [ -z "$KEEP_SPLIT" ]; then
+    rm -rf $SPLITDIR
+fi
 
-echo "The output is is $INPUT_FILE.out"
+echo "The output is in $OUTPUT_FILE"

--- a/pipe/src/main/scala/com/clearcut/pipe/Main.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/Main.scala
@@ -70,6 +70,17 @@ object Main extends App {
   val annotators:Array[Annotator[_,_]] = conf.annotators.split(",").map (s =>
       Class.forName("com.clearcut.pipe.annotator." + s.trim).newInstance().asInstanceOf[Annotator[_,_]])
 
+  // load configuration properties from properties file
+  if (new java.io.File("config.properties").exists) {
+    println("config.properties exists")
+    val prop = new java.util.Properties()
+    val fromFile = new java.io.FileReader("config.properties")
+    prop.load(fromFile)
+    fromFile.close
+    for (ann <- annotators)
+      ann.setProperties(prop)
+  }
+
   val reader:Reader = conf.formatIn match {
     case "column" => new ColumnReader(conf.in)
     case "json" => new JsonReader(conf.in, conf.idKey, conf.documentKey)

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/Annotator.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/Annotator.scala
@@ -1,10 +1,17 @@
 package com.clearcut.pipe.annotator
 
+import java.util.Properties
 import scala.reflect.runtime.universe._
 import com.clearcut.pipe.model._
 
 abstract class Annotator[In,Out](implicit inTag:TypeTag[In], outTag:TypeTag[Out])
   extends java.io.Serializable {
+
+  var properties = new Properties()
+
+  def setProperties(p:java.util.Properties) = {
+    properties = p
+  }
 
   def annotate(in:In):Out
 

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedCleanHtmlStanfordPipeline.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedCleanHtmlStanfordPipeline.scala
@@ -12,17 +12,18 @@ import org.jsoup.safety._
 class ExtendedCleanHtmlStanfordPipeline extends Annotator[(Text), (Html, SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
   SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets)] {
 
-  val props = new Properties()
-  props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
-  props.put("clean.xmltags", ".*")
-  props.put("parse.maxlen", "100")
-  props.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
-  props.put("parse.originalDependencies", "true")
-  props.put("truecase.model", "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz")
-  props.put("threads", "1") // Should use extractor-level parallelism
-  props.put("clean.allowflawedxml", "true")
-  props.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
-
+  override def setProperties(p:Properties) {
+    super.setProperties(p)
+    properties.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
+    properties.put("clean.xmltags", ".*")
+    properties.put("parse.maxlen", "100")
+    properties.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+    properties.put("truecase.model", "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz")
+    properties.put("threads", "1") // Should use extractor-level parallelism
+    properties.put("clean.allowflawedxml", "true")
+    properties.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
+  }
+  
   @transient lazy val pipeline = new StanfordCoreNLP(props)
 
   val stripHtml = Pattern.compile("<\\/?a|A[^>]*>")

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedCleanHtmlStanfordPipeline.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedCleanHtmlStanfordPipeline.scala
@@ -5,28 +5,49 @@ import edu.stanford.nlp.ling.CoreAnnotations.SentencesAnnotation
 import edu.stanford.nlp.pipeline.{StanfordCoreNLP, Annotation}
 import java.util.Properties
 import com.clearcut.pipe.model._
+import java.util.regex._
+import org.jsoup.Jsoup
+import org.jsoup.safety._
 
-class ExtendedStanfordPipeline extends Annotator[(Text), (SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
+class ExtendedCleanHtmlStanfordPipeline extends Annotator[(Text), (Html, SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
   SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets)] {
 
   val props = new Properties()
   props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
+  props.put("clean.xmltags", ".*")
   props.put("parse.maxlen", "100")
   props.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+  props.put("parse.originalDependencies", "true")
+  props.put("truecase.model", "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz")
   props.put("threads", "1") // Should use extractor-level parallelism
   props.put("clean.allowflawedxml", "true")
   props.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
 
   @transient lazy val pipeline = new StanfordCoreNLP(props)
 
-  override def annotate(t:Text):(SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas, SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets) = {
+  val stripHtml = Pattern.compile("<\\/?a|A[^>]*>")
+
+  override def annotate(t:Text):(Html, SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas, SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets) = {
+
+    // clean up Html
+    var text = extractCleanHtml(t)
+
     // Temporary fix for bug where brackets are being incorrectly treated as punct
     // and somehow this messes up the whole dep parse -> change them to round braces
-    // val text = t.replaceAll( """\[""", "(").replaceAll( """\]""", ")")
-    val text = t
+    text = text.replaceAll( """\[""", "(").replaceAll( """\]""", ")")
 
-    val stanAnn = new Annotation(text)
-    pipeline.annotate(stanAnn)
+    var stanAnn = new Annotation(text)
+    try {
+      pipeline.annotate(stanAnn)
+    
+    } catch {
+      // If our pipeline still fails on this input, we return an empty tuple.
+      case e:Exception =>
+         System.err.println(text)
+         e.printStackTrace(System.err)
+         System.err.flush()
+         return (text, Array[Offsets](), Array[Offsets](), Array[String](),           Array[String](), Array[String](), Array[String](), Array[Array[Dependency]](), Array[String](), Array[String](), Array[Offsets]())  
+    }
 
     val (toa, to) = StanfordTokenizer.fromStanford(stanAnn)
     val poss = StanfordPOSTagger.fromStanford(stanAnn)
@@ -37,7 +58,11 @@ class ExtendedStanfordPipeline extends Annotator[(Text), (SentenceOffsets, Token
     val pa = StanfordSRParser.fromStanford(stanAnn)
     val tcs = StanfordTrueCaseAnnotator.fromStanford(stanAnn)
 
-    (so, toa, to, poss, nertags, lemmas, deps, pa, tcs, sto)
+    (text, so, toa, to, poss, nertags, lemmas, deps, pa, tcs, sto)
+  }
+
+  def extractCleanHtml(html:String):String = {
+    val doc = Jsoup.parseBodyFragment(html).body()
+    doc.html()
   }
 }
-

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedHtmlStanfordPipeline.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedHtmlStanfordPipeline.scala
@@ -5,28 +5,49 @@ import edu.stanford.nlp.ling.CoreAnnotations.SentencesAnnotation
 import edu.stanford.nlp.pipeline.{StanfordCoreNLP, Annotation}
 import java.util.Properties
 import com.clearcut.pipe.model._
+import java.util.regex._
+import org.jsoup.Jsoup
+import org.jsoup.safety._
 
-class ExtendedStanfordPipeline extends Annotator[(Text), (SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
+class ExtendedHtmlStanfordPipeline extends Annotator[(Text), (Html, SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
   SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets)] {
 
   val props = new Properties()
   props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
+  props.put("clean.xmltags", ".*")
   props.put("parse.maxlen", "100")
   props.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+  props.put("truecase.model", "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz")
   props.put("threads", "1") // Should use extractor-level parallelism
   props.put("clean.allowflawedxml", "true")
   props.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
 
   @transient lazy val pipeline = new StanfordCoreNLP(props)
 
-  override def annotate(t:Text):(SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas, SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets) = {
+  val stripHtml = Pattern.compile("<\\/?a|A[^>]*>")
+
+  override def annotate(t:Text):(Html, SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas, SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets) = {
+
+    // clean up Html
+    //var text = extractCleanHtml(t)
+    var text = t
+
     // Temporary fix for bug where brackets are being incorrectly treated as punct
     // and somehow this messes up the whole dep parse -> change them to round braces
-    // val text = t.replaceAll( """\[""", "(").replaceAll( """\]""", ")")
-    val text = t
+    //text = text.replaceAll( """\[""", "(").replaceAll( """\]""", ")")
 
-    val stanAnn = new Annotation(text)
-    pipeline.annotate(stanAnn)
+    var stanAnn = new Annotation(text)
+    try {
+      pipeline.annotate(stanAnn)
+    
+    } catch {
+      // If our pipeline still fails on this input, we return an empty tuple.
+      case e:Exception =>
+         System.err.println(text)
+         e.printStackTrace(System.err)
+         System.err.flush()
+         return (text, Array[Offsets](), Array[Offsets](), Array[String](),           Array[String](), Array[String](), Array[String](), Array[Array[Dependency]](), Array[String](), Array[String](), Array[Offsets]())  
+    }
 
     val (toa, to) = StanfordTokenizer.fromStanford(stanAnn)
     val poss = StanfordPOSTagger.fromStanford(stanAnn)
@@ -37,7 +58,11 @@ class ExtendedStanfordPipeline extends Annotator[(Text), (SentenceOffsets, Token
     val pa = StanfordSRParser.fromStanford(stanAnn)
     val tcs = StanfordTrueCaseAnnotator.fromStanford(stanAnn)
 
-    (so, toa, to, poss, nertags, lemmas, deps, pa, tcs, sto)
+    (text, so, toa, to, poss, nertags, lemmas, deps, pa, tcs, sto)
+  }
+
+  def extractCleanHtml(html:String):String = {
+    val doc = Jsoup.parseBodyFragment(html).body()
+    doc.html()
   }
 }
-

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedHtmlStanfordPipeline.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedHtmlStanfordPipeline.scala
@@ -12,16 +12,18 @@ import org.jsoup.safety._
 class ExtendedHtmlStanfordPipeline extends Annotator[(Text), (Html, SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
   SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets)] {
 
-  val props = new Properties()
-  props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
-  props.put("clean.xmltags", ".*")
-  props.put("parse.maxlen", "100")
-  props.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
-  props.put("truecase.model", "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz")
-  props.put("threads", "1") // Should use extractor-level parallelism
-  props.put("clean.allowflawedxml", "true")
-  props.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
-
+  override def setProperties(p:Properties) {
+    super.setProperties(p)
+    properties.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
+    properties.put("clean.xmltags", ".*")
+    properties.put("parse.maxlen", "100")
+    properties.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+    properties.put("truecase.model", "edu/stanford/nlp/models/truecase/truecasing.fast.qn.ser.gz")
+    properties.put("threads", "1") // Should use extractor-level parallelism
+    properties.put("clean.allowflawedxml", "true")
+    properties.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
+  }
+  
   @transient lazy val pipeline = new StanfordCoreNLP(props)
 
   val stripHtml = Pattern.compile("<\\/?a|A[^>]*>")

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedStanfordPipeline.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/ExtendedStanfordPipeline.scala
@@ -9,14 +9,16 @@ import com.clearcut.pipe.model._
 class ExtendedStanfordPipeline extends Annotator[(Text), (SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
   SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets)] {
 
-  val props = new Properties()
-  props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
-  props.put("parse.maxlen", "100")
-  props.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
-  props.put("threads", "1") // Should use extractor-level parallelism
-  props.put("clean.allowflawedxml", "true")
-  props.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
-
+  override def setProperties(p:Properties) {
+    super.setProperties(p)
+    properties.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse, truecase")
+    properties.put("parse.maxlen", "100")
+    properties.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+    properties.put("threads", "1") // Should use extractor-level parallelism
+    properties.put("clean.allowflawedxml", "true")
+    properties.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
+  }
+  
   @transient lazy val pipeline = new StanfordCoreNLP(props)
 
   override def annotate(t:Text):(SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas, SentenceDependencies, Parses, TrueCases, SentenceTokenOffsets) = {

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/SimpleStanfordPipeline.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/SimpleStanfordPipeline.scala
@@ -7,15 +7,18 @@ import com.clearcut.pipe.model._
 class SimpleStanfordPipeline extends Annotator[(Text), (SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas,
   SentenceDependencies)] {
 
-  val props = new Properties()
-  props.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse")
-  props.put("parse.maxlen", "100")
-  props.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
-  props.put("threads", "1") // Should use extractor-level parallelism
-  props.put("clean.allowflawedxml", "true")
-  props.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
+  //val props = new Properties()
+  override def setProperties(p:Properties) {
+    super.setProperties(p)
+    properties.put("annotators", "tokenize, cleanxml, ssplit, pos, lemma, ner, parse")
+    properties.put("parse.maxlen", "100")
+    properties.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+    properties.put("threads", "1") // Should use extractor-level parallelism
+    properties.put("clean.allowflawedxml", "true")
+    properties.put("clean.sentenceendingtags", "p|br|div|li|ul|ol|h1|h2|h3|h4|h5|blockquote|section|article")
+  }
 
-  @transient lazy val pipeline = new StanfordCoreNLP(props)
+  @transient lazy val pipeline = new StanfordCoreNLP(properties)
 
   override def annotate(t:Text):(SentenceOffsets, TokenOffsets, Tokens, Poss, NerTags, Lemmas, SentenceDependencies) = {
     // Temporary fix for bug where brackets are being incorrectly treated as punct

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordCoreferenceResolver.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordCoreferenceResolver.scala
@@ -17,8 +17,6 @@ import scala.collection.mutable.ArrayBuffer
 class StanfordCoreferenceResolver extends Annotator[(Text,TokenOffsets,Tokens,SentenceOffsets,SentenceTokenOffsets,
 	Poss,NerTags,Parses,SentenceDependencies),(Mentions,Coreferences)] {
 
-	val properties = new Properties()
-
 	// make sure StanfordCoreNLP has parse annotator, which is needed by dcoref
   @transient lazy val stanfordAnnotator =
     AnnotatorFactories.coref(properties, StanfordUtil.annotatorImplementations).create()

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordLemmatizer.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordLemmatizer.scala
@@ -9,7 +9,6 @@ import edu.stanford.nlp.pipeline.{Annotation => StAnnotation, AnnotatorFactories
 /** Wraps CoreNLP Lemmatizer as an Annotator. */
 class StanfordLemmatizer extends Annotator[(Text, Poss, SentenceOffsets, TokenOffsets, Tokens), (Lemmas)] {
 
-  val properties = new Properties()
 	@transient lazy val stanfordAnnotator =
 		AnnotatorFactories.lemma(properties, StanfordUtil.annotatorImplementations).create()
 

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordNERTagger.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordNERTagger.scala
@@ -10,7 +10,6 @@ import java.util._
 /** Wraps CoreNLP NER Tagger as an Annotator. */
 class StanfordNERTagger extends Annotator[(Text,TokenOffsets,Tokens,SentenceOffsets,Lemmas,Poss), (NerTags)] {
 
-  val properties = new Properties()
   @transient lazy val stanfordAnnotator =
     AnnotatorFactories.nerTag(properties, StanfordUtil.annotatorImplementations).create()
 

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordPOSTagger.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordPOSTagger.scala
@@ -9,7 +9,6 @@ import java.util._
 /** Wraps CoreNLP POS Tagger as an Annotator. */
 class StanfordPOSTagger extends Annotator[(Text,TokenOffsets,Tokens,SentenceOffsets),(Poss)] {
   
-  val properties = new Properties()
   @transient lazy val stanfordAnnotator =
     AnnotatorFactories.posTag(properties, StanfordUtil.annotatorImplementations).create()
 

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordSRParser.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordSRParser.scala
@@ -17,11 +17,13 @@ import scala.collection.JavaConversions._
 class StanfordSRParser extends Annotator[(Text,SentenceOffsets,SentenceTokenOffsets,TokenOffsets,Tokens,Poss),
   (Parses,SentenceDependencies)] {
 
-  val properties = new Properties()
-  properties.setProperty("annotators", "tokenize,ssplit")
-  properties.put("parse.maxlen", "100")
-  properties.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
-  properties.put("threads", "1") // Should use extractor-level parallelism
+  override def setProperties(p:Properties) {
+    super.setProperties(p)
+    p.setProperty("annotators", "tokenize,ssplit")
+    p.put("parse.maxlen", "100")
+    p.put("parse.model", "edu/stanford/nlp/models/srparser/englishSR.ser.gz")
+    p.put("threads", "1") // Should use extractor-level parallelism
+  }
 
   @transient lazy val stanfordAnnotator =
     AnnotatorFactories.parse(properties, StanfordUtil.annotatorImplementations).create()

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordSentenceSplitter.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordSentenceSplitter.scala
@@ -24,7 +24,6 @@ import edu.stanford.nlp.util.CoreMap
 
 class StanfordSentenceSplitter extends Annotator[(Text,TokenOffsets,Tokens), (SentenceOffsets,SentenceTokenOffsets)] {
 
-	val properties = new Properties
 	@transient lazy val stanfordAnnotator =
 		AnnotatorFactories.sentenceSplit(properties, StanfordUtil.annotatorImplementations).create()
 
@@ -99,7 +98,7 @@ object StanfordSentenceSplitter {
 class StanfordSentenceSplitterWithFrags extends Annotator[(Text,TextFragments,TokenOffsets,Tokens),
 	(SentenceOffsets,SentenceTokenOffsets)] {
 
-  val properties = new Properties()
+  //val properties = new Properties()
   //@transient lazy val stanfordAnnotator = StanfordHelper.getAnnotator(properties, "ssplit")
 	@transient lazy val stanfordAnnotator =
 		AnnotatorFactories.sentenceSplit(properties, StanfordUtil.annotatorImplementations).create()

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordTokenizer.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordTokenizer.scala
@@ -10,8 +10,6 @@ import scala.collection.JavaConverters._
 /** Wraps CoreNLP Tokenizer as an Annotator. */
 class StanfordTokenizer extends Annotator[Text,(TokenOffsets,Tokens)] {
 
-  val properties = new Properties()
-
   @transient lazy val stanfordAnnotator =
     AnnotatorFactories.tokenize(properties, StanfordUtil.annotatorImplementations).create()
 

--- a/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordTrueCaseAnnotator.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/annotator/StanfordTrueCaseAnnotator.scala
@@ -9,7 +9,6 @@ import java.util._
 /** Wraps CoreNLP TrueCaseAnnotator as an Annotator. */
 class StanfordTrueCaseAnnotator extends Annotator[(Text,TokenOffsets,Tokens,SentenceOffsets),(TrueCases)] {
   
-  val properties = new Properties()
   @transient lazy val stanfordAnnotator =
     AnnotatorFactories.truecase(properties, StanfordUtil.annotatorImplementations).create()
 

--- a/pipe/src/main/scala/com/clearcut/pipe/io/ColumnWriter.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/io/ColumnWriter.scala
@@ -6,6 +6,7 @@ import com.clearcut.pipe.model._
 import com.clearcut.pipe.Schema
 
 class ColumnWriter(dir:String) extends Writer {
+  val BUFFER_SIZE = 10 * 1024 * 1024
 
   var writers:Array[BufferedWriter] = null
 
@@ -18,7 +19,7 @@ class ColumnWriter(dir:String) extends Writer {
         null
       else
         new BufferedWriter(
-          new OutputStreamWriter(new FileOutputStream(name)))
+          new OutputStreamWriter(new FileOutputStream(name)), BUFFER_SIZE)
     })
   }
 

--- a/pipe/src/main/scala/com/clearcut/pipe/io/JsonReader.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/io/JsonReader.scala
@@ -14,14 +14,14 @@ import scala.io.Source
 class JsonReader(in:String,
                  idKey:String, documentKey:String)
   extends Reader with Iterator[Array[AnyRef]] {
-
+  val BUFFER_SIZE = 10 * 1024 * 1024
 
   implicit val codec = new scala.io.Codec(
     java.nio.charset.Charset.forName("utf-8"))
   codec.onMalformedInput(CodingErrorAction.IGNORE)
   codec.onUnmappableCharacter(CodingErrorAction.IGNORE)
 
-  val reader = Source.fromFile(in)
+  val reader = Source.fromFile(new java.io.File(in), BUFFER_SIZE)
 
   var it = reader.getLines.zipWithIndex
   var _next = fetchNext()

--- a/pipe/src/main/scala/com/clearcut/pipe/model/package.scala
+++ b/pipe/src/main/scala/com/clearcut/pipe/model/package.scala
@@ -4,6 +4,7 @@ import com.clearcut.pipe.io.Json
 
 /** Set of our cross-language, minimalist schema */
 package object model {
+  type Html = String
   type Coreferences = Array[CoreferenceChain]
   type Dependencies = Array[Dependency]
   type Id = String

--- a/pipe/test/input.tsv
+++ b/pipe/test/input.tsv
@@ -1,2 +1,0 @@
-12	This is the content.	Here's another field with content.
-14	Another doc.	Again content here.


### PR DESCRIPTION
One can now add a `config.properties` file into the directory where one is calling Pipe. These settings are then passed through to the CoreNLP modules that are called. For example, if you want to parse pre-tokenized and pre-sentence-split content, you can add a `config.properties` file with the following entries:
```
tokenize.whitespace = true
ssplit.eolonly = true
```